### PR TITLE
Updating and fixing of the "Verification with Verilator"

### DIFF
--- a/verification/verilator/README.md
+++ b/verification/verilator/README.md
@@ -30,3 +30,25 @@
 1. Execute SW testbench with tracing `make verilator-run-traced`.
     - `make verilator-run-traced` should automatically execute `make verilator-build`.
 2. Inspect trace with GTKWave `gtkwave logs/vlt_dump.vcd`.
+
+### Troubleshooting
+
+#### Missing clock signal
+If you see an error like this:
+```python
+/src/generated/SomeSubsystem.sv
+Traceback (most recent call last):
+File "./verification/verilator/scripts/generate_bindings.py", line 74, in <module>
+clock_signal_name = clock_signal_names[path.name]
+~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
+KeyError: 'SomeSubsystem.sv'
+make: *** [Makefile:86: verilator-generate-bindings] Error 1
+```
+
+This means that the clock signal name is not defined in `verification/verilator/scripts/clock_signal_names.py`. You can add the clock signal name to the dictionary in `verification/verilator/scripts/clock_signal_names.py` and re-run the command.
+```python
+clock_signal_names = {
+    'SomeSubsystem.sv': 'clk',
+    'SomeOtherSubsystem.sv': 'clk',
+}
+```

--- a/verification/verilator/scripts/do_fix.sh
+++ b/verification/verilator/scripts/do_fix.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
-# Path to the file with issues
-# Todo: This is horrible - it should be flexible enough to work with any version of the AXI, but then again, this is a temporary fix until either AXI is fixed in the main repo (unlikely) or have some poor individual or collective maintain the issues here.
-# I could restore the old AXI_PATH="$(bender path axi)" instead, but again, it could cause the issue like last time where AXI package was updated and the old "fix" broke it even further.
-AXI_FILE=".bender/git/checkouts/axi-aae2d6c181d6f97b/src/axi_lite_mux.sv"
+# Determine the path to the AXI directory
+AXI_PATH=$(bender path axi)
+AXI_FILE="${AXI_PATH}/src/axi_lite_mux.sv"
 
-# Throw an error if the file doesn't exist and tell the user to go double check if anything has not been massively over hauled in the ".bender/git/checkouts/axi-[sha256]]/src/axi_lite_mux.sv" file
+# Check if the AXI file exists
 if [ ! -f "${AXI_FILE}" ]; then
     echo -e "\033[31mError: ${AXI_FILE} does not exist. Please check the path and try again.\033[0m"
-    echo -e "\033[35mNote: Please make sure that the AXI package is not massively overhauled, as this script is designed to work with a specific version of the AXI with hash aae2d6c181d6f97b - if it is the same rename the verification/verilator/scripts/do_fix.sh and undo_fix.sh.\033[0m"
+    exit 1
+fi
+
+# Check if the file has changed by comparing MD5 checksums - this is way to check if the fix is compatible with the current version
+KNOWN_CHECKSUM="d97f7e8c938da8ce7477e36d0cae0e60"  # Replace with the actual checksum of the known compatible version
+CURRENT_CHECKSUM=$(md5sum "${AXI_FILE}" | awk '{ print $1 }')
+
+# To future maintainers: please update the KNOWN_CHECKSUM variable with the checksum of the original file by running:
+# md5sum .bender/git/checkouts/axi-[SHA256]/src/axi_lite_mux.sv;
+
+if [ "${CURRENT_CHECKSUM}" != "${KNOWN_CHECKSUM}" ]; then
+    echo -e "\033[31mError: ${AXI_FILE} has changed. The fix may not be compatible with this version.\033[0m"
+    echo -e "\033[31mPlease ensure the fix is still compatible and if so update the KNOWN_CHECKSUM variable in the script.\033[0m"
     exit 1
 fi
 

--- a/verification/verilator/scripts/do_fix.sh
+++ b/verification/verilator/scripts/do_fix.sh
@@ -1,13 +1,50 @@
 #!/bin/bash
 
-AXI_PATH="$(bender path axi)"
+# Path to the file with issues
+# Todo: This is horrible - it should be flexible enough to work with any version of the AXI, but then again, this is a temporary fix until either AXI is fixed in the main repo (unlikely) or have some poor individual or collective maintain the issues here.
+# I could restore the old AXI_PATH="$(bender path axi)" instead, but again, it could cause the issue like last time where AXI package was updated and the old "fix" broke it even further.
+AXI_FILE=".bender/git/checkouts/axi-aae2d6c181d6f97b/src/axi_lite_mux.sv"
 
-# Comment out the failing code
-sed -i '125 i /*' $AXI_PATH/src/axi_lite_mux.sv
-sed -i '128 i */' $AXI_PATH/src/axi_lite_mux.sv
+# Throw an error if the file doesn't exist and tell the user to go double check if anything has not been massively over hauled in the ".bender/git/checkouts/axi-[sha256]]/src/axi_lite_mux.sv" file
+if [ ! -f "${AXI_FILE}" ]; then
+    echo -e "\033[31mError: ${AXI_FILE} does not exist. Please check the path and try again.\033[0m"
+    echo -e "\033[35mNote: Please make sure that the AXI package is not massively overhauled, as this script is designed to work with a specific version of the AXI with hash aae2d6c181d6f97b - if it is the same rename the verification/verilator/scripts/do_fix.sh and undo_fix.sh.\033[0m"
+    exit 1
+fi
 
-# Add working code
-sed -i '129 i // FIXME: previous does not work: see verilator problem 1' $AXI_PATH/src/axi_lite_mux.sv
-sed -i '130 i // This value is derived from file SysCtrl_xbar.sv parameter AXI4LITE_INITIATORS' $AXI_PATH/src/axi_lite_mux.sv
-sed -i '131 i localparam NoSlvPorts_fix_clog2_minus1 = 1;' $AXI_PATH/src/axi_lite_mux.sv
-sed -i '132 i typedef logic [NoSlvPorts_fix_clog2_minus1:0] select_t;' $AXI_PATH/src/axi_lite_mux.sv
+# Back up the original file if it doesn't exist already
+if [ ! -f "${AXI_FILE}.orig" ]; then
+    cp "${AXI_FILE}" "${AXI_FILE}.orig"
+    echo "Backed up original ${AXI_FILE} to ${AXI_FILE}.orig"
+fi
+
+# Restore from original before applying fixes
+if [ -f "${AXI_FILE}.orig" ]; then
+    cp "${AXI_FILE}.orig" "${AXI_FILE}"
+    echo "Restored original ${AXI_FILE} from backup"
+fi
+
+# Add Verilator lint_off directives at the top of the file
+sed -i.bak '12i\
+/* verilator lint_off SELRANGE */\
+/* verilator lint_off WIDTH */\
+' "${AXI_FILE}"
+
+echo "Applied lint_off directives to ${AXI_FILE}"
+
+# Find the line where select_t is defined and replace it with a fixed width version
+sed -i.bak 's/typedef logic \[$clog2(NoSlvPorts)-1:0\] select_t;/typedef logic [31:0] select_t;/' "${AXI_FILE}"
+
+# Fix B channel section (around line 193-195) - "Mida vittu" but this is the only way to fix the "Illegal bit or array select; type does not have a bit range, or bad dimension: data type is 'logic'"
+sed -i.bak 's/(b_select == select_t'\''(i))/(b_select == 32'\''(i))/g' "${AXI_FILE}"
+
+# Fix W channel section
+sed -i.bak 's/(w_select == select_t'\''(i))/(w_select == 32'\''(i))/g' "${AXI_FILE}"
+
+# Fix R channel section
+sed -i.bak 's/(r_select == select_t'\''(i))/(r_select == 32'\''(i))/g' "${AXI_FILE}"
+
+# Remove backup files created by sed
+rm -f "${AXI_FILE}.bak"
+
+echo "Applied fixes to ${AXI_FILE}"

--- a/verification/verilator/scripts/generate_bindings.py
+++ b/verification/verilator/scripts/generate_bindings.py
@@ -29,6 +29,7 @@ clock_signal_names = {
     "AX4LITE_APB_converter_wrapper.sv": "clk",
     "Student_SS_2.sv": "clk_in",
     "ICN_SS.sv": "clk",
+    "DtuSubsystem.sv": "clock",
     # Does not have clock signal...
     "pmod_mux.sv": None,
     "Student_area_0.sv": "clk_in",

--- a/verification/verilator/scripts/generate_bindings.py
+++ b/verification/verilator/scripts/generate_bindings.py
@@ -15,7 +15,7 @@ clock_signal_names = {
     "SysCtrl_peripherals_0.v": "clk",
     "Student_SS_2_0.v": "clk",
     "SysCtrl_SS_wrapper_0.v": "clk",
-    "Student_SS_1_0.v": "clk",
+    "Student_SS_1_0.v": "clk_in",
     "SysCtrl_SS_0.v": "clk_internal",
     "Student_SS_3_0.v": "clk_in",
     "jtag_dbg_wrapper.sv": "clk_i",

--- a/verification/verilator/scripts/run.sh
+++ b/verification/verilator/scripts/run.sh
@@ -56,6 +56,8 @@ WARN_SUPPRESS="\
     -Wno-TIMESCALEMOD \
     -Wno-REDEFMACRO"
 
+# Preprocessor RVFI required by the tracer, hence "-D[RVFI]", like mentioned in the sim/Makefile line 24 -
+# otherwise Verilator will not find the pins in the ibex's tracer top module
 verilator \
     --cc \
     --exe \

--- a/verification/verilator/scripts/run.sh
+++ b/verification/verilator/scripts/run.sh
@@ -62,6 +62,7 @@ verilator \
     --top-module Didactic \
     --no-timing \
     --trace \
+    --DRVFI \
     $DEFINES \
     $WARN_SUPPRESS \
     $INCLUDES \

--- a/verification/verilator/scripts/undo_fix.sh
+++ b/verification/verilator/scripts/undo_fix.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-AXI_PATH=$(bender path axi)
+# Path to the file with issues
+# Todo: See do_fix.sh Todo
+AXI_FILE=".bender/git/checkouts/axi-aae2d6c181d6f97b/src/axi_lite_mux.sv"
 
-# Remove changes
-sed -i '125d;128d;129d;130d;131d;132d' $AXI_PATH/src/axi_lite_mux.sv
+# Restore the original file if backup exists
+if [ -f "${AXI_FILE}.orig" ]; then
+    cp "${AXI_FILE}.orig" "${AXI_FILE}"
+    echo "Restored original ${AXI_FILE}"
+else
+    echo "No backup found for ${AXI_FILE}"
+fi

--- a/verification/verilator/scripts/undo_fix.sh
+++ b/verification/verilator/scripts/undo_fix.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-# Path to the file with issues
-# Todo: See do_fix.sh Todo
-AXI_FILE=".bender/git/checkouts/axi-aae2d6c181d6f97b/src/axi_lite_mux.sv"
+# Determine the path to the AXI directory
+AXI_PATH=$(bender path axi)
+AXI_FILE="${AXI_PATH}/src/axi_lite_mux.sv"
+
+# Check if the AXI file exists
+if [ ! -f "${AXI_FILE}" ]; then
+    echo -e "\033[31mError: ${AXI_FILE} does not exist. Please check the path and try again.\033[0m"
+    exit 1
+fi
+
 
 # Restore the original file if backup exists
 if [ -f "${AXI_FILE}.orig" ]; then
@@ -10,4 +17,16 @@ if [ -f "${AXI_FILE}.orig" ]; then
     echo "Restored original ${AXI_FILE}"
 else
     echo "No backup found for ${AXI_FILE}"
+fi
+
+# Check if the file has changed by comparing checksums, again - to ensure that file is actually restored
+KNOWN_CHECKSUM="d97f7e8c938da8ce7477e36d0cae0e60"  # Replace with the actual checksum of the known compatible version
+CURRENT_CHECKSUM=$(md5sum "${AXI_FILE}" | awk '{ print $1 }')
+
+# To future maintainers: please update the KNOWN_CHECKSUM variable with the checksum of the original file by running:
+# md5sum .bender/git/checkouts/axi-[SHA256]/src/axi_lite_mux.sv;
+
+if [ "${CURRENT_CHECKSUM}" != "${KNOWN_CHECKSUM}" ]; then
+    echo -e "\033[31mError: ${AXI_FILE} has changed. The undo fix may not be compatible with this version.\033[0m"
+    exit 1
 fi

--- a/verification/verilator/src/hdl/ms/Student_SS_1_0.sv
+++ b/verification/verilator/src/hdl/ms/Student_SS_1_0.sv
@@ -1,2 +1,2 @@
-`INCREMENT_CYCLE_COUNT(clk)
+`INCREMENT_CYCLE_COUNT(clk_in)
 `include "verification/verilator/src/generated/hdl/ms/Student_SS_1_0.sv"


### PR DESCRIPTION
Re-implemented the axi lite mux fix and created MD5 checksum validation of said file so in the the case if it gets changed, there is a warning to make sure that the made fix in question is still compatible or needs changing.
Added additional troubleshooting documentation for the Verilator Verification README.md
Added missing or renamed mismatches of the clock inputs of the generated source files.

Now it should be now actually possible to do Verilator verification once again.
