### PR TITLE
[rtl] register rdata and err in obi-apb bridge

### DIFF
--- a/src/reuse/obi_to_apb_intf.sv
+++ b/src/reuse/obi_to_apb_intf.sv
@@ -20,6 +20,9 @@ module obi_to_apb_intf #(
     // APB phase FSM
     typedef enum logic [1:0] {SETUP, ACCESS, HANDSHAKE} state_e;
     state_e state_d, state_q;
+
+    logic [31:0] data;
+    logic err;
   
     // Feed these through.
     assign apb_o.paddr  = obi_i.addr;
@@ -28,8 +31,8 @@ module obi_to_apb_intf #(
     assign apb_o.psel   = obi_i.req;
     assign apb_o.pstrb  = obi_i.be;
   
-    assign obi_i.err    = apb_o.pslverr;
-    assign obi_i.rdata  = apb_o.prdata;
+    assign obi_i.err    = err;
+    assign obi_i.rdata  = data;
   
     // Tie PPROT to {0: unprivileged, 1: non-secure, 0: data}
     assign apb_o.pprot   = 3'b010;
@@ -61,8 +64,12 @@ module obi_to_apb_intf #(
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
         state_q <= SETUP;
+        data <= 32'b0;
+        err <= 1'b0;
       end else begin
         state_q <= state_d;
+        data <= apb_o.prdata;
+        err <= apb_o.pslverr;
       end
     end
   


### PR DESCRIPTION
I was facing issues with the OBI-APB bridge. At the top of the screenshot, you can see an APB read access entering our subsystem and being responded with 0x01 (after one wait state). At the bottom, you can see the corresponding transaction at the OBI data interface of the Ibex. The access is only granted when our subsystem responds PREADY on the APB interface, and the read data is marked valid one cycle later, when our subsystem no longer provides valid data (since the APB transaction is already finished). This results in the wrong read data being captured by the Ibex. 

Since we want to avoid registering the request signals (address, wdata, be, ...), I suggest we keep the handshaking as it is, but we will have to register the read data and the error flag to keep it valid until rvalid is asserted.

<img width="1920" height="444" alt="image" src="https://github.com/user-attachments/assets/ef501e66-85f9-4ce6-b9f2-5924d91dac5b" />
