### PR TITLE
Correct variable name in sw/Makefile

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -35,7 +35,7 @@ hex_test:
 	sed -E 's/(..)(..)(..)(..)/\4\3\2\1/' < $(BUILD_DIR)/tmp_be.hex > $(BUILD_DIR)/tmp_le.hex
 
 trim:
-	head -$(shell wc -w < $(BUILD_DIR)/tmp_le.hex) $(BUILD_DIR)/tmp_le.hex > $(BUILD_DIR)/sw/$(TEST).hex
+	head -$(shell wc -w < $(BUILD_DIR)/tmp_le.hex) $(BUILD_DIR)/tmp_le.hex > $(BUILD_DIR)/sw/$(TESTCASE).hex
 
 dump:
 	$(OBJDUMP) $(BUILD_DIR)/sw/$(TESTCASE).elf -d > $(BUILD_DIR)/sw/$(TESTCASE).asm


### PR DESCRIPTION
Rename variable TEST to TESTCASE to correct the trim command